### PR TITLE
Change maxPickableObjectMass to maxPickableMass

### DIFF
--- a/LumberJack.lua
+++ b/LumberJack.lua
@@ -37,7 +37,7 @@ function LumberJack.prependPlayerReadUpdateStream(self, streamId, timestamp, con
         -- server code (read data from client)
         if connection == self.networkInformation.creatorConnection then
 			self.superStrengthEnabled = streamReadBool(streamId)
-            self.maxPickableObjectMass = streamReadFloat32(streamId)
+            self.maxPickableMass = streamReadFloat32(streamId)
             self.maxPickableObjectDistance = streamReadFloat32(streamId)
         end
     end
@@ -48,22 +48,22 @@ function LumberJack.prependPlayerWriteUpdateStream(self, streamId, connection, d
 		if self.superStrengthEnabled == nil then
 			self.superStrengthEnabled = LumberJack.superStrength
 		end
-		if self.maxPickableObjectMass == nil then
-			self.maxPickableObjectMass = LumberJack.normalStrengthValue
+		if self.maxPickableMass == nil then
+			self.maxPickableMass = LumberJack.normalStrengthValue
 		end
 		if self.maxPickableObjectDistance == nil then
 			self.maxPickableObjectDistance = LumberJack.normalDistanceValue
 		end
 		streamWriteBool(streamId, self.superStrengthEnabled)
-		streamWriteFloat32(streamId, self.maxPickableObjectMass)
+		streamWriteFloat32(streamId, self.maxPickableMass)
 		streamWriteFloat32(streamId, self.maxPickableObjectDistance)
     end
 end
 
 --REPLACE ALL INSTANCES OF Player.MAX_PICKABLE_OBJECT_MASS TO ENABLE CLIENT SUPERSETRENGTH IN MULTIPLAYER
 function LumberJack.playerThrowObject(self, superFunc, noEventSend)
-	if self.maxPickableObjectMass ~= nil then
-		Player.MAX_PICKABLE_OBJECT_MASS = self.maxPickableObjectMass
+	if self.maxPickableMass ~= nil then
+		Player.MAX_PICKABLE_OBJECT_MASS = self.maxPickableMass
 	end
 	return superFunc(self, noEventSend)
 end
@@ -74,14 +74,14 @@ function LumberJack.playerCheckObjectInRange(self, superFunc)
 	return superFunc(self)
 end
 function LumberJack.playerStatePickupIsAvailable(self, superFunc)
-	if self.player.maxPickableObjectMass ~= nil then
-		Player.MAX_PICKABLE_OBJECT_MASS = self.player.maxPickableObjectMass
+	if self.player.maxPickableMass ~= nil then
+		Player.MAX_PICKABLE_OBJECT_MASS = self.player.maxPickableMass
 	end
 	return superFunc(self)
 end
 function LumberJack.playerStateThrowIsAvailable(self, superFunc)
-	if self.player.maxPickableObjectMass ~= nil then
-		Player.MAX_PICKABLE_OBJECT_MASS = self.player.maxPickableObjectMass
+	if self.player.maxPickableMass ~= nil then
+		Player.MAX_PICKABLE_OBJECT_MASS = self.player.maxPickableMass
 	end
 	return superFunc(self)
 end
@@ -92,12 +92,12 @@ function LumberJack.playerConsoleCommand(self, superFunc)
 	if g_currentMission.player.superStrengthEnabled then
 		LumberJack.lockStrength = true
 		LumberJack.superStrength = true
-		g_currentMission.player.maxPickableObjectMass = LumberJack.superStrengthValue
+		g_currentMission.player.maxPickableMass = LumberJack.superStrengthValue
 		g_currentMission.player.maxPickableObjectDistance = LumberJack.superDistanceValue
 	else
 		LumberJack.lockStrength = false
 		LumberJack.superStrength = false
-		g_currentMission.player.maxPickableObjectMass = LumberJack.normalStrengthValue
+		g_currentMission.player.maxPickableMass = LumberJack.normalStrengthValue
 		g_currentMission.player.maxPickableObjectDistance = LumberJack.normalDistanceValue
 	end
 end
@@ -161,7 +161,7 @@ function LumberJack:toggleStrength(name, state)
 					--print("SUPER STRENGTH OFF")
 					LumberJack.superStrength = false
 					g_currentMission.player.superStrengthEnabled = LumberJack.superStrength
-					g_currentMission.player.maxPickableObjectMass = LumberJack.normalStrengthValue
+					g_currentMission.player.maxPickableMass = LumberJack.normalStrengthValue
 					g_currentMission.player.maxPickableObjectDistance = LumberJack.normalDistanceValue
 				end
 			else
@@ -169,7 +169,7 @@ function LumberJack:toggleStrength(name, state)
 					--print("SUPER STRENGTH ON")
 					LumberJack.superStrength = true
 					g_currentMission.player.superStrengthEnabled = LumberJack.superStrength
-					g_currentMission.player.maxPickableObjectMass = LumberJack.superStrengthValue
+					g_currentMission.player.maxPickableMass = LumberJack.superStrengthValue
 					g_currentMission.player.maxPickableObjectDistance = LumberJack.superDistanceValue
 				end
 			end
@@ -187,7 +187,7 @@ function LumberJack:update(dt)
 	-- CHANGE GLOBAL VALUES ON FIRST RUN
 	if (g_gameStateManager:getGameState()==GameState.PLAY and LumberJack.initialised==false) then
 		LumberJack.playerID = g_currentMission.player.controllerIndex
-		g_currentMission.player.maxPickableObjectMass = LumberJack.normalStrengthValue
+		g_currentMission.player.maxPickableMass = LumberJack.normalStrengthValue
 		g_currentMission.player.maxPickableObjectDistance = LumberJack.normalDistanceValue
 		
 		-- enable active objects debugging output:
@@ -235,7 +235,7 @@ function LumberJack:update(dt)
 			g_currentMission.player.aimOverlay:setColor(1, 1, 1, 1.0)
 			g_currentMission.player.pickedUpObjectOverlay:setColor(1, 1, 1, 1.0)
 		else
-			if g_currentMission.player.isObjectInRange and g_currentMission.player.lastFoundObjectMass > g_currentMission.player.maxPickableObjectMass then
+			if g_currentMission.player.isObjectInRange and g_currentMission.player.lastFoundObjectMass > g_currentMission.player.maxPickableMass then
 				-- Make hand RED when objects are too heavy to pick up
 				g_currentMission.player.pickedUpObjectOverlay:setColor(1.0, 0.1, 0.1, 0.5)
 			else


### PR DESCRIPTION
FS22 1.8.1 update changed the variable that is checked against when seeing if object is available for pickup. See `scripts/PlayerStatePickup.lua#31` when extracting SDK from 1.8.1

Fixes #6 

```lua
--- scripts/PlayerStatePickup.lua#31
-- @return bool true if player can idle
function PlayerStatePickup:isAvailable()
    if self.player.isClient and self.player.isEntered and not self.player:hasHandtoolEquipped() then
        if not self.player.isCarryingObject and self.player.isObjectInRange then
            if self.player.lastFoundObjectMass <= self.player.maxPickableMass then
                return true
            else
                g_currentMission:addExtraPrintText(g_i18n:getText("warning_objectTooHeavy"))
            end
        end
    end
    return false
end
```
